### PR TITLE
Added Email/Password Authentication Option

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+
+interface Props {
+  message: string;
+  type?: "success" | "error";
+  onClose: () => void;
+  duration?: number;
+}
+
+export default function Alert({ message, type = "success", onClose, duration = 5000 }: Props) {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onClose();
+    }, duration);
+    return () => clearTimeout(timer);
+  }, [duration, onClose]);
+
+  const bgColor = type === "success" ? "bg-green-600" : "bg-red-600";
+
+  return (
+    <div
+      className={`${bgColor} text-white px-4 py-3 rounded-lg shadow-md fixed top-6 right-6 z-50 transition-opacity duration-500`}
+    >
+      <div className="flex justify-between items-center">
+        <span>{message}</span>
+        <button
+          onClick={onClose}
+          className="ml-4 text-white hover:text-gray-200 font-bold"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Auth/EmailLoginForm.tsx
+++ b/src/components/Auth/EmailLoginForm.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import ResetPasswordModal from "./ResetPasswordModal";
+import { useNavigate } from "react-router-dom";
+import Alert from "../Alert";
+
+interface Props {
+  onSwitchToRegister: () => void;
+  onBack: () => void;
+}
+
+export default function EmailLoginForm({ onSwitchToRegister, onBack }: Props) {
+  const { signInWithEmail } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [showResetModal, setShowResetModal] = useState(false);
+  const [showSuccessAlert, setShowSuccessAlert] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const startTime = Date.now();
+
+    try {
+      await signInWithEmail(email, password);
+
+      const elapsed = Date.now() - startTime;
+      const remaining = 2000 - elapsed;
+      if (remaining > 0) {
+        await new Promise((res) => setTimeout(res, remaining));
+      }
+
+      setShowSuccessAlert(true);
+
+      setTimeout(() => {
+        navigate("/");
+      }, 500);
+    } catch {
+      setError('Invalid email or password');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-dark-900">
+      <div className="w-full max-w-sm p-6 bg-dark-800 rounded-xl shadow-lg">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-dark-100 mb-2">Log In</h1>
+          <p className="text-dark-300">Enter your email address and password</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Email"
+            className="w-full p-3 rounded-lg border border-dark-600 bg-dark-900 text-dark-100"
+          />
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+            className="w-full p-3 rounded-lg border border-dark-600 bg-dark-900 text-dark-100"
+          />
+          <p className="text-sm text-right text-dark-300 mt-1 mb-4">
+            <button
+              type="button"
+              onClick={() => setShowResetModal(true)}
+              className="hover:underline"
+            >
+              Forgot password?
+            </button>
+          </p>
+
+          {error && <p className="text-red-400 text-sm">{error}</p>}
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full p-3 bg-dark-700 text-dark-100 rounded-lg hover:bg-dark-600 transition-smooth flex justify-center"
+          >
+            {loading ? (
+              <div className="h-5 w-5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+            ) : (
+              "Login"
+            )}
+          </button>
+        </form>
+
+        <div className="flex justify-between mt-4 text-sm text-dark-300">
+          <button onClick={onBack} className="hover:underline">← Back</button>
+          <button onClick={onSwitchToRegister} className="hover:underline">
+            Don't have an account? Register
+          </button>
+        </div>
+      </div>
+
+      <ResetPasswordModal
+        isOpen={showResetModal}
+        onClose={() => setShowResetModal(false)}
+      />
+
+      {showSuccessAlert && (
+        <Alert
+          message="Login successful"
+          type="success"
+          onClose={() => setShowSuccessAlert(false)}
+          duration={5000}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/Auth/EmailRegisterForm.tsx
+++ b/src/components/Auth/EmailRegisterForm.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import VerificationModal from './VerificationModal';
+
+interface Props {
+  onSwitchToLogin: () => void;
+  onBack: () => void;
+}
+
+export default function EmailRegisterForm({ onSwitchToLogin, onBack }: Props) {
+  const { signUpWithEmail } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [repeatPassword, setRepeatPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [showVerificationModal, setShowVerificationModal] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+
+    const startTime = Date.now();
+
+    if (password !== repeatPassword) {
+      setError("Passwords do not match");
+      return;
+    }
+
+    try {
+      await signUpWithEmail(email, password);
+
+      const elapsed = Date.now() - startTime;
+      const remaining = 2000 - elapsed;
+      if (remaining > 0) {
+        await new Promise((res) => setTimeout(res, remaining));
+      }
+
+      setShowVerificationModal(true);
+    } catch (err) {
+      setError('Could not create account');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-dark-900">
+      <div className="w-full max-w-sm p-6 bg-dark-800 rounded-xl shadow-lg">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-dark-100 mb-2">Register</h1>
+          <p className="text-dark-300">Fill in your details below</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Email"
+            className="w-full p-3 rounded-lg border border-dark-600 bg-dark-900 text-dark-100"
+          />
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+            className="w-full p-3 rounded-lg border border-dark-600 bg-dark-900 text-dark-100"
+          />
+          <input
+            type="password"
+            value={repeatPassword}
+            onChange={(e) => setRepeatPassword(e.target.value)}
+            placeholder="Repeat Password"
+            className="w-full p-3 rounded-lg border border-dark-600 bg-dark-900 text-dark-100"
+          />
+
+          {error && <p className="text-red-400 text-sm">{error}</p>}
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full p-3 bg-dark-700 text-dark-100 rounded-lg hover:bg-dark-600 transition-smooth flex justify-center"
+          >
+            {loading ? (
+              <div className="h-5 w-5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+            ) : ("Register"
+
+            )}
+          </button>
+        </form>
+
+        <div className="flex justify-between mt-4 text-sm text-dark-300">
+          <button onClick={onBack} className="hover:underline">← Back</button>
+          <button onClick={onSwitchToLogin} className="hover:underline">
+            Already have an account? Login
+          </button>
+        </div>
+      </div>
+
+      {showVerificationModal && (
+        <VerificationModal onClose={onSwitchToLogin} />
+      )}
+    </div>
+  );
+}

--- a/src/components/Auth/ResetPasswordModal.tsx
+++ b/src/components/Auth/ResetPasswordModal.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { useAuth } from "../../contexts/AuthContext";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function ResetPasswordModal({ isOpen, onClose }: Props) {
+  const { resetPassword } = useAuth();
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setMessage(null);
+    setError(null);
+
+    try {
+      await resetPassword(email);
+      setMessage("Password reset link has been sent to your email.");
+    } catch {
+      setError("Failed to send password reset link. Please try again.");
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
+      <div className="bg-dark-800 rounded-xl shadow-lg p-6 w-full max-w-sm">
+        <h2 className="text-xl font-bold text-dark-100 mb-4">Reset Password</h2>
+        <p className="text-dark-300 mb-4">
+          Enter your email and we’ll send you a link to reset your password.
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Email"
+            className="w-full p-3 rounded-lg border border-dark-600 bg-dark-900 text-dark-100"
+            required
+          />
+
+          {error && <p className="text-red-400 text-sm">{error}</p>}
+          {message && <p className="text-green-400 text-sm">{message}</p>}
+
+          <div className="flex justify-between mt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 rounded-lg bg-dark-700 hover:bg-dark-600 text-dark-100"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white"
+            >
+              Send Reset Link
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Auth/VerificationModal.tsx
+++ b/src/components/Auth/VerificationModal.tsx
@@ -1,0 +1,23 @@
+interface Props {
+  onClose: () => void;
+}
+
+export default function VerificationModal({ onClose }: Props) {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-60">
+      <div className="bg-dark-800 p-6 rounded-xl shadow-lg text-center max-w-sm w-full">
+        <h2 className="text-xl font-bold text-dark-100 mb-4">Verify your email</h2>
+        <p className="text-dark-300 mb-6">
+          We sent you a verification link. Please check your inbox and confirm your email.
+          After verifying, you can log in.
+        </p>
+        <button
+          onClick={onClose}
+          className="w-full p-3 bg-dark-700 text-dark-100 rounded-lg hover:bg-dark-600"
+        >
+          Back to Login
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -5,9 +5,12 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { ErrorFallback } from '../components/ErrorFallback';
 import { toast } from 'react-hot-toast';
+import EmailLoginForm from '../components/Auth/EmailLoginForm';
+import EmailRegisterForm from '../components/Auth/EmailRegisterForm';
 
 function Login() {
   const { signInWithGoogle, signInWithGithub } = useAuth();
+  const [view, setView] = useState<'social' | 'email-login' | 'email-register'>('social');
   const navigate = useNavigate();
   const [error, setError] = useState<Error | null>(null);
   const [isOnline, setIsOnline] = useState(navigator.onLine);
@@ -56,11 +59,29 @@ function Login() {
     }
   };
 
+  if (view === 'email-login') {
+    return (
+      <EmailLoginForm
+        onSwitchToRegister={() => setView('email-register')}
+        onBack={() => setView('social')}
+      />
+    );
+  }
+
+  if (view === 'email-register') {
+    return (
+      <EmailRegisterForm
+        onSwitchToLogin={() => setView('email-login')}
+        onBack={() => setView('social')}
+      />
+    );
+  }
+
   if (error) {
     return (
-      <ErrorFallback 
-        error={error} 
-        resetErrorBoundary={() => setError(null)} 
+      <ErrorFallback
+        error={error}
+        resetErrorBoundary={() => setError(null)}
       />
     );
   }
@@ -93,11 +114,10 @@ function Login() {
           </button>
 
           <button
-            disabled
-            className="w-full flex items-center justify-center space-x-2 p-3 border border-dark-600 rounded-lg text-dark-400 cursor-not-allowed opacity-50"
+            onClick={() => setView('email-login')}
+            className="w-full p-3 bg-dark-700 text-white rounded-lg hover:bg-dark-600"
           >
-            <FiMail className="w-5 h-5" />
-            <span>Continue with Email (Coming Soon)</span>
+            Continue with Email
           </button>
         </div>
 


### PR DESCRIPTION
[Add Email/Password Authentication Option #2](https://github.com/suraniharsh/CodeCandy/issues/2)

- I modified continue-with-email button:
<img width="1919" height="858" alt="image" src="https://github.com/user-attachments/assets/ffe7f7cb-02ca-4cc7-86c7-0ef5fb763ce6" />

- Implemented sigining in and up with email/password credentials:
**Log in**
Log in view:
<img width="1919" height="859" alt="image" src="https://github.com/user-attachments/assets/4f1e29f6-4cb9-472c-9b4b-4476eec083a8" />

If user does not remember their password, they can use "Forgot password" button that opens modal:
<img width="436" height="276" alt="image" src="https://github.com/user-attachments/assets/5c713eca-2fcb-4bac-aefc-6a51f796b2cc" />

User then gets an email, that redirects to change-password-page (default template provided by Firebase)

**Register**
Register view:
<img width="1919" height="868" alt="image" src="https://github.com/user-attachments/assets/71992c9a-6551-4847-b5d2-8fead8cb2ac8" />

After the user passes their credentails, the verify-your-email modal opens:
<img width="426" height="260" alt="image" src="https://github.com/user-attachments/assets/4d016830-a55c-4a3a-adaa-0a6b8813ede7" />

When the user verfies the email, they are redirected back to /login page.
